### PR TITLE
Explicitly set status message

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -36,7 +36,7 @@ class UbuntuCharm(CharmBase):
         set the application-level workload version to the Ubuntu version upon
         which the charm is running.
         """
-        self.unit.status = ActiveStatus()
+        self.unit.status = ActiveStatus("ready")
         if not self.unit.is_leader():
             return
         try:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -51,3 +51,10 @@ class TestCharm(TestCase):
         self.mPath.assert_called_with("/etc/hostname")
         self.mPath().write_text.assert_called_once_with("foo")
         self.mcheck_call.assert_called_once_with(["hostname", "foo"])
+
+    def test_charm_ready(self):
+        """
+        See: https://github.com/openstack-charmers/zaza/blob/master/zaza/model.py#L1636
+        """
+        prefixes = ["ready", "Ready", "Unit is ready"]
+        self.assertIn(self.harness.model.unit.status.message, prefixes)


### PR DESCRIPTION
zaza and other frameworks need a specific message to be set for a charm to be marked as ready. This PR does this for the ubuntu charm.