### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security policy
+
+## Supported versions
+
+The security support lifetime for a charm-ubuntu deployment mirrors the
+[Ubuntu release lifecycle](https://ubuntu.com/about/release-cycle) of the base
+being deployed. LTS releases receive standard security maintenance for 5 years;
+interim releases receive security maintenance for 9 months. Once a given Ubuntu
+base reaches end-of-life, that base is no longer security-maintained in this
+project.
+
+## Reporting a vulnerability
+
+Please provide a description of the issue, the steps you took to
+create the issue, affected versions, and, if known, mitigations for
+the issue.
+
+The easiest way to report a security issue is through
+[GitHub's security advisory for this project](https://github.com/canonical/charm-ubuntu/security/advisories/new). See
+[Privately reporting a security
+vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
+for instructions on reporting using GitHub's security advisory feature.
+
+The charm-ubuntu GitHub admins will be notified of the issue and will work with you
+to determine whether the issue qualifies as a security issue and, if so, in
+which component. We will then figure out a fix, get a CVE
+assigned, and coordinate the release of the fix.
+
+You may also send email to security@ubuntu.com. If you want to encrypt your email,
+follow [Canonical's reporting instructions](https://ubuntu.com/security/disclosure-policy#contact-us).
+
+If you have a deadline for public disclosure, please let us know.
+Our vulnerability management team intends to respond within 3 working
+days of your report. This project aims to resolve all vulnerabilities
+within 90 days.
+
+The [Ubuntu Security disclosure and embargo
+policy](https://ubuntu.com/security/disclosure-policy) contains more
+information about what you can expect when you contact us, and what we
+expect from you.


### PR DESCRIPTION
Adds `SECURITY.md` to `canonical/charm-ubuntu`, modelled on `canonical/operator/SECURITY.md`. Adopts the Ubuntu disclosure/embargo policy as standard across Charm Tech repos.

Two repo-specific adjustments:

- **Reporting a vulnerability:** advisory link points to this repo; admin reference reads "the charm-ubuntu GitHub admins". All other wording (3-working-day / 90-day, `security@ubuntu.com`, Canonical reporting instructions, Ubuntu disclosure-policy footer) matches the operator template verbatim.
- **Supported versions:** keyed to the lifecycle of the Ubuntu base being deployed (LTS: 5y standard maintenance; interim: 9 months) rather than the generic "all major versions in the last year" wording, since this charm's security-maintenance window depends on the deployed base.