### PR TITLE
ci: add TIOBE quality checks workflow

### DIFF
--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -1,0 +1,49 @@
+name: TIOBE Quality Checks
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '38 2 * * 0'
+
+permissions: {}
+
+jobs:
+  TICS:
+    runs-on: [self-hosted, reactive, amd64, tiobe, noble]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+
+        # We could store the coverage report from the regular run, but this is cheap to do
+        # and keeps this isolated.
+      - name: Generate coverage report
+        run: |
+          pip install coverage pytest ipdb -r requirements.txt --break-system-packages
+          PYTHONPATH=src coverage run --source=src -m pytest tests/unit
+          mkdir -p .report
+          coverage xml -o .report/coverage.xml
+
+        # Note that these are dependencies for the tools that the TIOBE action will run,
+        # which is done in the global environment, rather than a venv, as we do with the
+        # unit tests.
+      - name: Install TIOBE and project dependencies
+        run: |
+          pip install flake8 pylint -r requirements.txt --break-system-packages
+
+      - name: TICS GitHub Action
+        uses: tiobe/tics-github-action@3300ccc8de3c938cb83dc940ec4d07096c1bf185  # v3.9.1
+        with:
+          mode: qserver
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          project: ubuntu
+          installTics: true

--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -27,7 +27,7 @@ jobs:
         # and keeps this isolated.
       - name: Generate coverage report
         run: |
-          pip install coverage pytest ipdb -r requirements.txt --break-system-packages
+          pip install coverage pytest -r requirements.txt --break-system-packages
           PYTHONPATH=src coverage run --source=src -m pytest tests/unit
           mkdir -p .report
           coverage xml -o .report/coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 *.pyc
 build/
 *.charm
+.coverage
+


### PR DESCRIPTION
Add a TIOBE/TICS quality-checks workflow modelled on the ones in canonical/operator and canonical/jubilant, adapted to this repo's tox/pip tooling. Runs on the self-hosted TIOBE runner, generates a coverage report for the unit tests, and uploads to TICS using the org-level TICSAUTHTOKEN secret.