### PR TITLE
ci: add SBOM and secscan workflow

### DIFF
--- a/.github/.sbomber-manifest.yaml
+++ b/.github/.sbomber-manifest.yaml
@@ -1,0 +1,28 @@
+clients:
+  sbom:
+    service_url: https://sbom-request.canonical.com
+    department: charm_engineering
+    email: tony.meyer@canonical.com
+    team: charm_tech
+  secscan: {}
+
+artifacts:
+  - name: ubuntu
+    type: charm
+    channel: '2.x/stable'
+    base: ubuntu@18.04
+
+  - name: ubuntu
+    type: charm
+    channel: '2.x/stable'
+    base: ubuntu@20.04
+
+  - name: ubuntu
+    type: charm
+    channel: '2.x/stable'
+    base: ubuntu@22.04
+
+  - name: ubuntu
+    type: charm
+    channel: '2.x/stable'
+    base: ubuntu@24.04

--- a/.github/workflows/sbom-secscan.yaml
+++ b/.github/workflows/sbom-secscan.yaml
@@ -1,0 +1,25 @@
+name: SBOM and secscan
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run on the 10th of April and October, aligned to the Canonical release cycle.
+    - cron: "0 0 10 4,10 *"
+
+permissions: {}
+
+jobs:
+  scan:
+    name: SBOM and secscan
+    runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: sbomber
+        uses: canonical/sbomber/.github/actions/run@cf7a76e810497ec932e8285b2c9d6b373d225e79  # main -- the sbomber-ref input below should match
+        with:
+          manifest: ${{ github.workspace }}/.github/.sbomber-manifest.yaml
+          artifact-name: secscan-report-upload
+          sbomber-ref: cf7a76e810497ec932e8285b2c9d6b373d225e79  # should match the ref in 'uses' above


### PR DESCRIPTION
The Ubuntu charm is a Charm Tech product so should have the standard SSDLC secscan process.

- Adds `.github/.sbomber-manifest.yaml` pointing at the `ubuntu` charm on charmhub (`2.x/stable`, `ubuntu@20.04`)
- Adds `.github/workflows/sbom-secscan.yaml` to run the sbomber scan on a cycle-aligned schedule (10 April and October) and via `workflow_dispatch`

We currently have automated publishing for this charm, so the workflow runs once per cycle, meeting the SSDLC minimum requirements. If we add automated publishing in the future, we should adjust this workflow to be triggered by that.