### PR TITLE
ci: correct the TIOBE project name

### DIFF
--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -1,4 +1,4 @@
-name: TIOBE Quality Checks
+name: TIOBE
 
 on:
   workflow_dispatch:
@@ -45,5 +45,5 @@ jobs:
           mode: qserver
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
-          project: ubuntu
+          project: charm-ubuntu
           installTics: true

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ __pycache__/
 build/
 *.charm
 .coverage
+.report
 


### PR DESCRIPTION
The annoying thing about new workflows that run only on the hosted runners is not being able to test them fully. In #74 I got the name of the project wrong and don't notice until I was able to run the action after merge.

Fix the name, also make the workflow name shorter, and add the coverage folder to gitignore just in case.