### PR TITLE
ci: add dependency-review-action on PRs

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,0 +1,25 @@
+name: Dependency review
+
+on:
+  pull_request:
+    branches:
+      - master
+
+permissions: {}
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+    - name: Dependency review
+      uses: actions/dependency-review-action@v4
+      with:
+        fail-on-severity: high
+        comment-summary-in-pr: on-failure


### PR DESCRIPTION
This PR adds a scan of dependency manifest changes introduced in pull requests against the OSV vulnerability database and the configured licence policy, and comments on the PR when a high-severity vulnerability is found so it can be addressed before merge.

This adds a new action, but it's from GitHub and is the natural partner with dependabot.