### PR TITLE
test: run unit tests with warnings as errors

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,9 +3,12 @@ from pathlib import Path
 from unittest import TestCase, mock
 
 import yaml
+import ops.testing
 from ops.testing import Harness
 
 import charm
+
+ops.testing.SIMULATE_CAN_CONNECT = True
 
 
 def charm_config() -> str:

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     pytest
     ipdb
     -r{toxinidir}/requirements.txt
-commands = pytest --tb native --show-capture=no --log-cli-level=INFO -s --disable-warnings {posargs} {toxinidir}/tests/unit
+commands = pytest --tb native --show-capture=no --log-cli-level=INFO -s -W error -W "ignore:'cgi' is deprecated:DeprecationWarning" {posargs} {toxinidir}/tests/unit
 
 [testenv:integration]
 deps =


### PR DESCRIPTION
This PR turns `-W error` on for the unit tests. Honestly, very little is gained right now, given that there are three tests, the charm is still using ops 1.5, and is using Harness. However, when the charm is modernised (#62), the warnings-as-errors setting should be kept, and everything should be able to be clean. Ignoring specific warnings is better than the existing "ignore all" behaviour anyway.

The PR sets SIMULATE_CAN_CONNECT = True in the tests, to avoid a warning, and because with the version of Harness being used it's the right thing to do anyway.

There's a warning about the cgi module (in the stdlib) being deprecated, which comes from the old ops. Explicitly ignore that - it will go away when ops 2.23 and 3.x are used.