### PR TITLE
ci: add edge publish and manual promote workflows

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -1,0 +1,86 @@
+name: Promote charm
+
+on:
+  workflow_dispatch:
+    inputs:
+      from-channel:
+        description: Source channel risk to promote from
+        type: choice
+        required: true
+        default: edge
+        options:
+          - edge
+          - beta
+          - candidate
+      to-channel:
+        description: Target channel risk to promote to
+        type: choice
+        required: true
+        default: beta
+        options:
+          - beta
+          - candidate
+          - stable
+      track:
+        description: Track to promote within
+        type: string
+        required: true
+        default: latest
+
+permissions: {}
+
+jobs:
+  promote:
+    name: Promote ${{ inputs.track }}/${{ inputs.from-channel }} to ${{ inputs.track }}/${{ inputs.to-channel }}
+    runs-on: ubuntu-latest
+    environment: charmhub-promote
+    steps:
+      - name: Check out code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          persist-credentials: false
+
+      - name: Install charmcraft
+        run: |
+          sudo snap install charmcraft --classic
+
+      - name: Promote revisions
+        env:
+          CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
+          FROM_CHANNEL: ${{ inputs.from-channel }}
+          TO_CHANNEL: ${{ inputs.to-channel }}
+          TRACK: ${{ inputs.track }}
+        run: |
+          set -euo pipefail
+          charm_name=$(awk '/^name:/ {print $2; exit}' charmcraft.yaml)
+          charmcraft status "$charm_name" --format=json > status.json
+          python3 - <<'PY' > revisions.txt
+          import json, os, sys
+          with open("status.json") as f:
+              status = json.load(f)
+          track = os.environ["TRACK"]
+          risk = os.environ["FROM_CHANNEL"]
+          revisions = set()
+          for track_entry in status:
+              if track_entry.get("track") != track:
+                  continue
+              for mapping in track_entry.get("mappings", []):
+                  for channel in mapping.get("channels", []):
+                      if channel.get("risk") != risk:
+                          continue
+                      rev = channel.get("revision")
+                      if rev is not None:
+                          revisions.add(int(rev))
+          if not revisions:
+              print(f"No revisions found in {track}/{risk}", file=sys.stderr)
+              sys.exit(1)
+          for r in sorted(revisions):
+              print(r)
+          PY
+          echo "Revisions to promote:"
+          cat revisions.txt
+          while read -r revision; do
+            [ -z "$revision" ] && continue
+            echo "Releasing revision $revision to $TRACK/$TO_CHANNEL"
+            charmcraft release "$charm_name" --revision "$revision" --channel="$TRACK/$TO_CHANNEL"
+          done < revisions.txt

--- a/.github/workflows/publish-edge.yaml
+++ b/.github/workflows/publish-edge.yaml
@@ -3,7 +3,6 @@ name: Publish to edge
 on:
   push:
     branches:
-      - main
       - master
 
 permissions: {}

--- a/.github/workflows/publish-edge.yaml
+++ b/.github/workflows/publish-edge.yaml
@@ -1,0 +1,50 @@
+name: Publish to edge
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Build and publish to edge
+    runs-on: ubuntu-latest
+    environment: charmhub-edge
+    steps:
+      - name: Check out code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          persist-credentials: false
+
+      - name: Install charmcraft
+        run: |
+          sudo snap install charmcraft --classic
+
+      - name: Pack charm
+        run: |
+          charmcraft pack --verbose
+
+      - name: Upload and release to edge
+        env:
+          CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
+        run: |
+          set -euo pipefail
+          charm_name=$(awk '/^name:/ {print $2; exit}' charmcraft.yaml)
+          shopt -s nullglob
+          artefacts=(*.charm)
+          if [ ${#artefacts[@]} -eq 0 ]; then
+            echo "No .charm files produced by charmcraft pack" >&2
+            exit 1
+          fi
+          for charm in "${artefacts[@]}"; do
+            echo "::group::Uploading $charm"
+            upload_json=$(charmcraft upload "$charm" --format=json)
+            echo "$upload_json"
+            revision=$(printf '%s' "$upload_json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["revision"])')
+            echo "Uploaded $charm as revision $revision"
+            charmcraft release "$charm_name" --revision "$revision" --channel=latest/edge
+            echo "::endgroup::"
+          done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,3 +66,34 @@ charmcraft.spread -v -debug -reuse lxd:ubuntu-26.04:tests/spread/integration/ubu
 ```
 
 If you already have a Juju controller and a machine cloud set up and want to skip the spread wrapper, `make integration-execution` runs the pytest invocation directly (this is the same target the spread VM uses internally).
+
+# Publishing
+
+Every merge to `master` is packed and released to `latest/edge` by the [Publish to edge](.github/workflows/publish-edge.yaml) workflow. Promotion to `beta`, `candidate`, or `stable` is done manually via the [Promote charm](.github/workflows/promote.yaml) workflow (Actions → Promote charm → Run workflow), which is gated by a required-reviewer approval on the `charmhub-promote` environment.
+
+Both workflows authenticate to Charmhub using a `CHARMCRAFT_AUTH` secret configured on the `charmhub-edge` and `charmhub-promote` environments in this repo's settings.
+
+## Regenerating the `CHARMCRAFT_AUTH` secret
+
+The exported credentials have a time-to-live (we use one year). When they expire, or if they are ever exposed, generate a new one:
+
+1. On a machine with `charmcraft` installed and an account that has publisher rights on the `ubuntu` charm, run:
+
+   ```bash
+   charmcraft login \
+     --export=auth.txt \
+     --charm=ubuntu \
+     --permission=package-manage \
+     --permission=package-view \
+     --ttl=31536000
+   ```
+
+   `--ttl` is in seconds (`31536000` = one year).
+
+2. Copy the full contents of `auth.txt`.
+
+3. In GitHub, go to **Settings → Environments** and update the `CHARMCRAFT_AUTH` secret on both the `charmhub-edge` and `charmhub-promote` environments with the new value.
+
+4. Delete the local `auth.txt` (`shred -u auth.txt`) — the credentials are not encrypted.
+
+5. Once the new secret is in place, revoke the previous credentials with `charmcraft logout` on the machine you used to create them (or via Charmhub's session management if you no longer have the token).


### PR DESCRIPTION
Publish to latest/edge on every push to main, and add a workflow_dispatch promote workflow gated by a required-reviewer environment for beta/candidate/stable. Document the CHARMCRAFT_AUTH secret and how to regenerate it in CONTRIBUTING.md.