### PR TITLE
ci: use concierge to get charmcraft

### DIFF
--- a/.github/workflows/publish-edge.yaml
+++ b/.github/workflows/publish-edge.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up runner
         run: |
           sudo snap install --classic concierge
-          sudo concierge prepare --trace -p machine
+          sudo concierge prepare --trace -p crafts
 
       - name: Pack charm
         run: |

--- a/.github/workflows/publish-edge.yaml
+++ b/.github/workflows/publish-edge.yaml
@@ -18,9 +18,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install charmcraft
+      - name: Set up runner
         run: |
-          sudo snap install charmcraft --classic
+          sudo snap install --classic concierge
+          sudo concierge prepare --trace -p machine
 
       - name: Pack charm
         run: |

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -16,7 +16,6 @@ jobs:
       - name: Set up runner
         run: |
           sudo snap install --classic concierge
-          sudo snap install --classic charmcraft
           sudo concierge prepare --trace -p machine
 
       - name: Build charm
@@ -56,7 +55,6 @@ jobs:
       - name: Set up runner
         run: |
           sudo snap install --classic concierge
-          sudo snap install --classic charmcraft
           sudo concierge prepare --trace -p machine
 
       - name: Run spread


### PR DESCRIPTION
Install charmcraft via concierge so it takes care of appropriate groups and so on.