### PR TITLE
ci: collect logs on pack failure and skip installing unneeded snaps

### DIFF
--- a/.github/concierge-pack.yaml
+++ b/.github/concierge-pack.yaml
@@ -1,0 +1,11 @@
+juju:
+  disable: true
+
+providers:
+  lxd:
+    enable: true
+    bootstrap: false
+
+host:
+  snaps:
+    charmcraft:

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -65,10 +65,11 @@ jobs:
               if track_entry.get("track") != track:
                   continue
               for mapping in track_entry.get("mappings", []):
-                  for channel in mapping.get("channels", []):
-                      if channel.get("risk") != risk:
+                  for release in mapping.get("releases", []):
+                      parts = release.get("channel", "").split("/", 2)
+                      if len(parts) < 2 or parts[0] != track or parts[1] != risk:
                           continue
-                      rev = channel.get("revision")
+                      rev = release.get("revision")
                       if rev is not None:
                           revisions.add(int(rev))
           if not revisions:

--- a/.github/workflows/publish-edge.yaml
+++ b/.github/workflows/publish-edge.yaml
@@ -21,11 +21,19 @@ jobs:
       - name: Set up runner
         run: |
           sudo snap install --classic concierge
-          sudo concierge prepare --trace -p crafts
+          sudo concierge prepare --trace -c .github/concierge-pack.yaml
 
       - name: Pack charm
         run: |
           charmcraft pack --verbose
+
+      - name: Archive charmcraft logs
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: charmcraft-logs
+          path: /home/runner/.local/state/charmcraft/log/*.log
+          if-no-files-found: warn
 
       - name: Upload and release to edge
         env:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -48,11 +48,14 @@ platforms:
   ubuntu@26.04:ppc64el:
 
 parts:
+  uv-deps:
+    plugin: nil
+    build-snaps:
+      - astral-uv
   charm:
     plugin: uv
     source: .
-    build-snaps:
-      - astral-uv
+    after: [uv-deps]
   icon:
     plugin: dump
     source: .

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -48,14 +48,11 @@ platforms:
   ubuntu@26.04:ppc64el:
 
 parts:
-  uv-deps:
-    plugin: nil
-    build-snaps:
-      - astral-uv
   charm:
     plugin: uv
     source: .
-    after: [uv-deps]
+    build-snaps:
+      - astral-uv
   icon:
     plugin: dump
     source: .


### PR DESCRIPTION
The publish-edge job [failed](https://github.com/canonical/charm-ubuntu/actions/runs/28907087457/attempts/1) at charmcraft pack with:

> Environment validation failed for part 'charm': 'uv' not found and part 'charm' does not depend on a part named 'uv-deps' that would satisfy the dependency.

I can't reproduce this locally, and the build-snaps approach has definitely worked elsewhere many times. I haven't been able to figure out why it fails, so a I'm collecting logs so it will be clear if it fails again. I've also taken the opportunity to add a minimal concierge config as discussed in the last PR.

I've also bundled in a fix for the [failing promote job](https://github.com/canonical/charm-ubuntu/actions/runs/28910426766/job/85766464510).