### PR TITLE
ci: release each revision individually

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -80,10 +80,8 @@ jobs:
           PY
           echo "Revisions to promote:"
           cat revisions.txt
-          revision_args=()
           while read -r revision; do
             [ -z "$revision" ] && continue
-            revision_args+=(--revision "$revision")
+            echo "Releasing revision $revision to $TRACK/$TO_CHANNEL"
+            charmcraft release "$charm_name" --revision "$revision" --channel="$TRACK/$TO_CHANNEL"
           done < revisions.txt
-          echo "Releasing revisions to $TRACK/$TO_CHANNEL"
-          charmcraft release "$charm_name" "${revision_args[@]}" --channel="$TRACK/$TO_CHANNEL"

--- a/.github/workflows/publish-edge.yaml
+++ b/.github/workflows/publish-edge.yaml
@@ -83,14 +83,12 @@ jobs:
             echo "No .charm files downloaded from pack jobs" >&2
             exit 1
           fi
-          revision_args=()
           for charm in "${artefacts[@]}"; do
             echo "::group::Uploading $charm"
             upload_json=$(charmcraft upload "$charm" --format=json)
             echo "$upload_json"
             revision=$(printf '%s' "$upload_json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["revision"])')
             echo "Uploaded $charm as revision $revision"
-            revision_args+=(--revision "$revision")
+            charmcraft release "$charm_name" --revision "$revision" --channel=latest/edge
             echo "::endgroup::"
           done
-          charmcraft release "$charm_name" "${revision_args[@]}" --channel=latest/edge


### PR DESCRIPTION
`charmcraft release --revision` accepts only a single value per invocation (SingleOptionEnsurer), so #100's batched call fails with:

  Error: argument -r/--revision: invalid ... value: '34'

Revert to one `charmcraft release` call per revision. Charmhub tracks channel state per (base, architecture), so releasing each platform-specific revision individually leaves all platforms on the channel.