### PR TITLE
ci: restore packages permission for integration tests

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -8,6 +8,13 @@ jobs:
     permissions:
       actions: read
       contents: read
+      # The charm-ci build job declares packages: write (for pushing rock
+      # images to the registry). Reusable workflows can't request permissions
+      # conditionally, so the caller must grant it even when no images are
+      # pushed — without it every run fails at startup with "the nested job
+      # 'build' is requesting 'packages: write', but is only allowed
+      # 'packages: none'".
+      packages: write
     uses: canonical/charm-ci/.github/workflows/integration-test.yml@5fe9ef70e1f78106e4b9c3b61ae143fe10f970d3  # v0.0.1-alpha.9
     with:
       working-directory: .


### PR DESCRIPTION
The charm-ci reusable `integration-test.yml` workflow declares `packages: write` on its `build` job (used for pushing rock images to the registry), and reusable workflows cannot request permissions conditionally — so the caller must grant it even when no images are pushed.

The permission was dropped in a late iteration of #108, and since then every Integration Tests run has failed at startup with:

> Invalid workflow file: the nested job 'build' is requesting 'packages: write', but is only allowed 'packages: none'.

Because no successful integration-test run exists for the current tree, the publish workflow's resolve-run gate on master also fails (e.g. [run 29971494689](https://github.com/canonical/charm-ubuntu/actions/runs/29971494689)). Restoring the permission fixes both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)